### PR TITLE
Fix GitHub Pages configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -33,23 +33,13 @@ jobs:
         run: npm ci
       
       - name: Build
-        run: npm run build
+        run: npm run deploy
+        env:
+          NODE_ENV: production
       
-      - name: Setup Pages
-        uses: actions/configure-pages@v4
-      
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: './dist'
-
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
       - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: dist
+          branch: gh-pages
+          clean: true


### PR DESCRIPTION
这个PR修复了GitHub Pages的配置问题：

1. 创建了gh-pages分支作为GitHub Pages的基础
2. 更新了GitHub Actions工作流文件，使用JamesIves/github-pages-deploy-action来部署到gh-pages分支
3. 修改了权限设置，允许工作流写入仓库内容

这些更改将确保GitHub Pages能够正确部署。