### PR TITLE
Fix GitHub Pages deployment configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,8 +34,6 @@ jobs:
       
       - name: Build
         run: npm run deploy
-        env:
-          NODE_ENV: production
       
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "deploy": "NODE_ENV=production vite build && touch dist/.nojekyll"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^5.0.3",

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,6 +5,12 @@ import { svelte } from '@sveltejs/vite-plugin-svelte'
 export default defineConfig({
   base: process.env.NODE_ENV === 'production' ? '/llm-assist-signal-app/' : '/',
   plugins: [svelte()],
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    assetsDir: 'assets',
+    sourcemap: false
+  },
   server: {
     host: '0.0.0.0',
     port: 12000,


### PR DESCRIPTION
这个PR修复了GitHub Pages部署配置问题：

1. 添加了deploy脚本到package.json文件中
2. 修改了GitHub Actions工作流文件，移除了重复的环境变量设置
3. 添加了build配置到vite.config.js文件中

这些更改将确保GitHub Pages能够正确部署。